### PR TITLE
Caleb

### DIFF
--- a/src/main/java/controllers/InitConfigScreenController.java
+++ b/src/main/java/controllers/InitConfigScreenController.java
@@ -43,9 +43,10 @@ public class InitConfigScreenController extends Controller {
     @FXML protected void onConfirmButtonPress(ActionEvent event) {
         if (new File(directory + System.getProperty("file.separator") + "snappy_photos").exists()) {
             Alert alert = new Alert(Alert.AlertType.WARNING,
-                "The snappy_photos folder already exists. Click \"Finish\" to use the existing folder and all of its contents. Click \"Previous\" to select a different folder location.",
-                javafx.scene.control.ButtonType.PREVIOUS,
+                "The snappy_photos folder already exists. Click \"Finish\" to use the existing folder and all of its contents. Click \"Cancel\" to select a different folder location.",
+                javafx.scene.control.ButtonType.CANCEL,
                 javafx.scene.control.ButtonType.FINISH);
+            //alert.setOnCloseRequest(EventHandler<DialogEvent> event -> stage.close());
             alert.setTitle("Attention");
             alert.setHeaderText("Folder Already Exists");
             java.util.Optional<javafx.scene.control.ButtonType> result = alert.showAndWait();
@@ -59,7 +60,7 @@ public class InitConfigScreenController extends Controller {
     }
 
     @FXML protected void onCancelButtonPress(ActionEvent event) {
-        stage.close();
+        System.exit(0);
     }
 
     public String getDirectory() {

--- a/src/main/java/controllers/InitConfigScreenController.java
+++ b/src/main/java/controllers/InitConfigScreenController.java
@@ -4,7 +4,9 @@ import java.io.File;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
 import javafx.stage.DirectoryChooser;
 
@@ -17,9 +19,16 @@ public class InitConfigScreenController extends Controller {
 
     private DirectoryChooser dirChooser;
     private String directory;
-    private boolean confirmed = false;
+
+    @FXML protected void initialize() {
+        //Sets default directory to user's home directory
+        String home = System.getProperty("user.home");
+        directoryField.setText(home);
+        directory = home;
+    }
 
     @FXML protected void onSelectDirButtonPress(ActionEvent event) {
+        //Changes selected directory to whichever location user selects
         dirChooser = new DirectoryChooser();
         File photosdir = dirChooser.showDialog(stage);
         if (photosdir != null) {
@@ -32,8 +41,21 @@ public class InitConfigScreenController extends Controller {
     }
 
     @FXML protected void onConfirmButtonPress(ActionEvent event) {
-        confirmed = true;
-        stage.close();
+        if (new File(directory + System.getProperty("file.separator") + "snappy_photos").exists()) {
+            Alert alert = new Alert(Alert.AlertType.WARNING,
+                "The snappy_photos folder already exists. Click \"Finish\" to use the existing folder and all of its contents. Click \"Previous\" to select a different folder location.",
+                javafx.scene.control.ButtonType.PREVIOUS,
+                javafx.scene.control.ButtonType.FINISH);
+            alert.setTitle("Attention");
+            alert.setHeaderText("Folder Already Exists");
+            java.util.Optional<javafx.scene.control.ButtonType> result = alert.showAndWait();
+            System.out.println(result.get());
+            if (result.get() == ButtonType.FINISH) {
+                stage.close();
+            }
+        } else {
+            stage.close();
+        }
     }
 
     @FXML protected void onCancelButtonPress(ActionEvent event) {
@@ -41,9 +63,6 @@ public class InitConfigScreenController extends Controller {
     }
 
     public String getDirectory() {
-        if (confirmed) {
-            return directory;
-        }
-        return null;
+        return directory;
     }
 }

--- a/src/main/java/fxapp/Main.java
+++ b/src/main/java/fxapp/Main.java
@@ -34,20 +34,14 @@ public class Main extends Application {
             File configFile = new File(System.getProperty("user.home") + delim
                 + ".snappy" + delim + "config" + delim + "config.properties");
             if (!configFile.exists()) {
-                configFile.getParentFile().mkdirs();
-                configFile.createNewFile();
-            }
-            configInput = new FileInputStream(configFile);
-            prop.load(configInput);
-            configInput.close();
 
-            if (prop.getProperty("photosdir") == null) {
                 secondaryStage = new Stage();
                 loader = new FXMLLoader();
                 loader.setLocation(getClass().getResource("/fxml/initialsetupscreen.fxml"));
 
                 secondaryStage.setTitle("Welcome to Snappy!");
                 secondaryStage.setScene(new Scene(loader.load()));
+                secondaryStage.setOnCloseRequest(event -> System.exit(1));
                 InitConfigScreenController initController = loader.getController();
                 initController.setStage(secondaryStage);
                 secondaryStage.showAndWait();
@@ -56,12 +50,22 @@ public class Main extends Application {
                     validSetup = true;
                     File newDir = new File(initController.getDirectory() + delim + "snappy_photos");
                     newDir.mkdir();
+
+                    configFile.getParentFile().mkdirs();
+                    configFile.createNewFile();
+                    configInput = new FileInputStream(configFile);
+                    prop.load(configInput);
+                    configInput.close();
+
                     prop.setProperty("photosdir", initController.getDirectory() + delim + "snappy_photos");
                     OutputStream configOutput = new FileOutputStream(configFile);
                     prop.store(configOutput, null);
                     configOutput.close();
                 }
             } else {
+                configInput = new FileInputStream(configFile);
+                prop.load(configInput);
+                configInput.close();
                 validSetup = true;
             }
 

--- a/src/main/resources/fxml/initialsetupscreen.fxml
+++ b/src/main/resources/fxml/initialsetupscreen.fxml
@@ -12,14 +12,14 @@
             <Font size="33.0" />
          </font>
       </Label>
-      <Label fx:id="directoryField" layoutX="83.0" layoutY="240.0" prefHeight="25.0" prefWidth="446.0" text="No directory selected" textAlignment="RIGHT">
+      <Label fx:id="directoryField" layoutX="83.0" layoutY="240.0" prefHeight="25.0" prefWidth="446.0" textAlignment="RIGHT">
          <graphic>
             <Button fx:id="selectDirButton" mnemonicParsing="false" onAction="#onSelectDirButtonPress" text="Select" />
          </graphic>
       </Label>
       <Label layoutX="77.0" layoutY="99.0" prefHeight="118.0" prefWidth="446.0" text="Hi there! If you are reading this, it is most likely your first time using Snappy. We have detected that no image folder is set for this application. In order to start using this app, you will need set a directory where Snappy can create this folder. Please select a directory where there is enough diskspace for your needs, as Snappy will be storing all its photos and tags in the folder that it creates in this directory." wrapText="true" />
       <Label fx:id="sizeField" layoutX="83.0" layoutY="272.0" prefHeight="25.0" prefWidth="446.0" />
-      <Button fx:id="confirmButton" disable="true" layoutX="444.0" layoutY="323.0" mnemonicParsing="false" onAction="#onConfirmButtonPress" text="Confirm" />
+      <Button fx:id="confirmButton" layoutX="444.0" layoutY="323.0" mnemonicParsing="false" onAction="#onConfirmButtonPress" text="Confirm" />
       <Button cancelButton="true" layoutX="382.0" layoutY="323.0" mnemonicParsing="false" onAction="#onCancelButtonPress" text="Cancel" />
    </children>
 </Pane>


### PR DESCRIPTION
Set up initial startup screen. Can close/cancel and be returned to startup screen when re-opening application. Warning/option to use or find new folder location if snappy_photos already exists.